### PR TITLE
Dated subdirectories.

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -107,8 +107,10 @@ static int parse_outputs(libconfig::Setting &outs, channel_t *channel, int i, in
 				cerr << "both directory and filename_template required for file\n";
 				error();
 			}
-			fdata->basename = (char *)XCALLOC(1, strlen(outs[o]["directory"]) + strlen(outs[o]["filename_template"]) + 2);
-			sprintf(fdata->basename, "%s/%s", (const char *)outs[o]["directory"], (const char *)outs[o]["filename_template"]);
+			fdata->basedir = strdup(outs[o]["directory"]);
+			fdata->basename = strdup(outs[o]["filename_template"]);
+			fdata->dated_subdirectories = outs[o].exists("dated_subdirectories") ?
+				(bool)(outs[o]["dated_subdirectories"]) : false;
 			fdata->suffix = strdup(".mp3");
 
 			fdata->continuous = outs[o].exists("continuous") ?
@@ -146,8 +148,10 @@ static int parse_outputs(libconfig::Setting &outs, channel_t *channel, int i, in
 				error();
 			}
 
-			fdata->basename = (char *)XCALLOC(1, strlen(outs[o]["directory"]) + strlen(outs[o]["filename_template"]) + 2);
-			sprintf(fdata->basename, "%s/%s", (const char *)outs[o]["directory"], (const char *)outs[o]["filename_template"]);
+			fdata->basedir = strdup(outs[o]["directory"]);
+			fdata->basename = strdup(outs[o]["filename_template"]);
+			fdata->dated_subdirectories = outs[o].exists("dated_subdirectories") ?
+				(bool)(outs[o]["dated_subdirectories"]) : false;
 			fdata->suffix = strdup(".cf32");
 
 			fdata->continuous = outs[o].exists("continuous") ?

--- a/src/rtl_airband.h
+++ b/src/rtl_airband.h
@@ -128,10 +128,13 @@ struct icecast_data {
 };
 
 struct file_data {
+	char *basedir;
+	char *dir;
 	char *basename;
 	char *suffix;
 	char *file_path;
 	char *file_path_tmp;
+	bool dated_subdirectories;
 	bool continuous;
 	bool append;
 	bool split_on_transmission;


### PR DESCRIPTION
When output files collected with split_on_transmission are being collected for a long time the output directories become inconvenient to navigate. They can have a huge amount of individual .mp3 files. This patch adds a configuration option that will put files in dated subdirectories.

For example, the file:
  output_dir/prefix_20230831_204504.mp3

with the dated_subdirectories option will be saved like so:
  output_dir/2023/08/31/prefix_20230831_204504.mp3

Proposed wiki addition:
* `dated_subdirectories` (boolean, optional) - when enabled will create daily subdirectories under the specified directory. The directories follow the pattern directory/YYYY/MM/DD. The default is false.