### PR TITLE
Dated subdirectories.

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -107,8 +107,10 @@ static int parse_outputs(libconfig::Setting &outs, channel_t *channel, int i, in
 				cerr << "both directory and filename_template required for file\n";
 				error();
 			}
-			fdata->basename = (char *)XCALLOC(1, strlen(outs[o]["directory"]) + strlen(outs[o]["filename_template"]) + 2);
-			sprintf(fdata->basename, "%s/%s", (const char *)outs[o]["directory"], (const char *)outs[o]["filename_template"]);
+			fdata->basedir = strdup(outs[o]["directory"]);
+			fdata->basename = strdup(outs[o]["filename_template"]);
+			fdata->dated_subdirectories = outs[o].exists("dated_subdirectories") ?
+				(bool)(outs[o]["dated_subdirectories"]) : false;
 			fdata->suffix = strdup(".mp3");
 
 			fdata->continuous = outs[o].exists("continuous") ?
@@ -146,8 +148,10 @@ static int parse_outputs(libconfig::Setting &outs, channel_t *channel, int i, in
 				error();
 			}
 
-			fdata->basename = (char *)XCALLOC(1, strlen(outs[o]["directory"]) + strlen(outs[o]["filename_template"]) + 2);
-			sprintf(fdata->basename, "%s/%s", (const char *)outs[o]["directory"], (const char *)outs[o]["filename_template"]);
+			fdata->basedir = strdup(outs[o]["directory"]);
+			fdata->basename = strdup(outs[o]["filename_template"]);
+			fdata->dated_subdirectories = outs[o].exists("dated_subdirectories") ?
+				(bool)(outs[o]["dated_subdirectories"]) : false;
 			fdata->suffix = strdup(".cf32");
 
 			fdata->continuous = outs[o].exists("continuous") ?

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -321,6 +321,8 @@ static void close_file(channel_t *channel, file_data *fdata) {
 	fdata->file_path = NULL;
 	free(fdata->file_path_tmp);
 	fdata->file_path_tmp = NULL;
+	free(fdata->dir);
+	fdata->dir = NULL;
 }
 
 char* make_dated_subdirectory(const char* basedir, const struct tm *time) {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -323,6 +323,61 @@ static void close_file(channel_t *channel, file_data *fdata) {
 	fdata->file_path_tmp = NULL;
 }
 
+char* make_dated_subdirectory(const char* basedir, const struct tm *time) {
+	size_t subdir_max_len = strlen(basedir) + 1 + 5 + 3 + 3 + 1;
+	char* subdir = (char*)XCALLOC(1, subdir_max_len);
+
+	// Most likely the subdirectory already exists.
+	// Let's try stat() first.
+	snprintf(subdir, subdir_max_len, "%s/%04d/%02d/%02d", basedir, time->tm_year+1900, time->tm_mon+1, time->tm_mday);
+	struct stat st;
+	if (stat(subdir, &st) == 0 && S_ISDIR(st.st_mode)) {
+		return subdir;
+	}
+
+	// It doesn't exist, let's create it, starting from the top.
+
+	// Year
+	snprintf(subdir, subdir_max_len, "%s/%04d", basedir, time->tm_year+1900);
+	if (mkdir(subdir, 0755) < 0 && errno != EEXIST) {
+		log(LOG_ERR, "Could not create directory %s: %s\n", subdir, strerror(errno));
+		free(subdir);
+		return NULL;
+	}
+
+	// Month
+	snprintf(subdir, subdir_max_len, "%s/%04d/%02d", basedir, time->tm_year+1900, time->tm_mon+1);
+	if (mkdir(subdir, 0755) < 0 && errno != EEXIST) {
+		log(LOG_ERR, "Could not create directory %s: %s\n", subdir, strerror(errno));
+		free(subdir);
+		return NULL;
+	}
+
+	// Day
+	snprintf(subdir, subdir_max_len, "%s/%04d/%02d/%02d", basedir, time->tm_year+1900, time->tm_mon+1, time->tm_mday);
+	if (mkdir(subdir, 0755) < 0 && errno != EEXIST) {
+		log(LOG_ERR, "Could not create directory %s: %s\n", subdir, strerror(errno));
+		free(subdir);
+		return NULL;
+	}
+
+	// It may not be a directory (mkdir would return EEXIST).
+	// Check that it is a directory.
+
+	if (stat(subdir, &st) == 0) {
+		if (!S_ISDIR(st.st_mode)) {
+			log(LOG_ERR, "%s exists but is not a directory\n", subdir);
+			free(subdir);
+			return NULL;
+		}
+	} else {
+		log(LOG_ERR, "Created directory %s, but it doesn't exist?: %s\n", subdir, strerror(errno));
+		free(subdir);
+		return NULL;
+	}
+	return subdir;
+}
+
 /*
  * Close current output file based on certain conditions:
  * If "split_on_transmission" mode is true check:
@@ -409,12 +464,22 @@ static bool output_file_ready(channel_t *channel, file_data *fdata, mix_modes mi
 		return false;
 	}
 
-	size_t file_path_len = strlen(fdata->basename) + strlen(timestamp) + strlen(fdata->suffix) + 11; // include space for '\0' and possible freq in Hz
+	if (fdata->dated_subdirectories) {
+		fdata->dir = make_dated_subdirectory(fdata->basedir, time);
+		if (fdata->dir == NULL) {
+			log(LOG_ERR, "Failed to create dated subdirectory\n");
+			return false;
+		}
+	} else {
+		fdata->dir = strdup(fdata->basedir);
+	}
+
+	size_t file_path_len = strlen(fdata->dir) + 1 + strlen(fdata->basename) + strlen(timestamp) + strlen(fdata->suffix) + 11; // include space for '\0' and possible freq in Hz
 	fdata->file_path = (char *)XCALLOC(1, file_path_len);
 	if (fdata->include_freq) {
-		sprintf(fdata->file_path, "%s%s_%d%s", fdata->basename, timestamp, channel->freqlist[channel->freq_idx].frequency, fdata->suffix);
+		sprintf(fdata->file_path, "%s/%s%s_%d%s", fdata->dir, fdata->basename, timestamp, channel->freqlist[channel->freq_idx].frequency, fdata->suffix);
 	} else {
-		sprintf(fdata->file_path, "%s%s%s", fdata->basename, timestamp, fdata->suffix);
+		sprintf(fdata->file_path, "%s/%s%s%s", fdata->dir, fdata->basename, timestamp, fdata->suffix);
 	}
 
 	static char const *tmp_suffix = ".tmp";

--- a/src/rtl_airband.h
+++ b/src/rtl_airband.h
@@ -128,10 +128,13 @@ struct icecast_data {
 };
 
 struct file_data {
+	char *basedir;
+	char *dir;
 	char *basename;
 	char *suffix;
 	char *file_path;
 	char *file_path_tmp;
+	bool dated_subdirectories;
 	bool continuous;
 	bool append;
 	bool split_on_transmission;


### PR DESCRIPTION
When output files collected with split_on_transmission are being collected for a long time the output directories become inconvenient to navigate. They can have a huge amount of individual .mp3 files. This patch adds a configuration option that will put files in dated subdirectories.

For example, the file:
  output_dir/prefix_20230831_204504.mp3

with the dated_subdirectories option will be saved like so:
  output_dir/2023/08/31/prefix_20230831_204504.mp3

Proposed wiki addition:
* `dated_subdirectories` (boolean, optional) - when enabled will create daily subdirectories under the specified directory. The directories follow the pattern directory/YYYY/MM/DD. The default is false.