### PR TITLE
Added new configuration settings.

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -120,6 +120,33 @@ static int parse_outputs(libconfig::Setting &outs, channel_t *channel, int i, in
 				(bool)(outs[o]["include_freq"]) : false;
 			channel->need_mp3 = 1;
 
+            if(outs[o].exists("transmission_delay"))
+            {
+                fdata->max_transmission_idle_sec = outs[o]["transmission_delay"];
+            }
+            else
+            {
+                fdata->max_transmission_idle_sec = 0.5;
+            }
+
+            if(outs[o].exists("minimum_transmission"))
+            {
+                fdata->min_transmission_time_sec = outs[o]["minimum_transmission"];
+            }
+            else
+            {
+                fdata->min_transmission_time_sec = 1.0;
+            }
+
+            if(outs[o].exists("max_transmission") && fdata->split_on_transmission)
+            {
+                fdata->max_transmission_time_sec = outs[o]["max_transmission"];
+            }
+            else
+            {
+                fdata->max_transmission_time_sec = 3600;
+            }
+
 			if(fdata->split_on_transmission) {
 				if (parsing_mixers) {
 					cerr<<"Configuration error: mixers.["<<i<<"] outputs.["<<o<<"]: split_on_transmission is not allowed for mixers\n";

--- a/src/rtl_airband.h
+++ b/src/rtl_airband.h
@@ -140,6 +140,9 @@ struct file_data {
 	timeval last_write_time;
 	FILE *f;
 	enum output_type type;
+    float min_transmission_time_sec;
+    float max_transmission_time_sec;
+    float max_transmission_idle_sec;
 };
 
 struct udp_stream_data {


### PR DESCRIPTION
transmission_delay_sec : default 0.5 : How long to wait for more transmissions before closing file

max_transmission_sec : default 3600 : Max length a transmission can be before starting a new file. (If split on transmission is false it uses default)

minimum_transmission_sec: default 1.0 : Minimum length a transmission can be. Anything lower is not saved to file.

Changed timestamp on split file to be epoch time with 2 decimals for milliseconds. Not human readable, but makes it easier for scripts to understand.

Timestamp for hourly file still the same string human readable timestamp