### PR TITLE
Fix for incorrect build configuration for RPi4

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -202,6 +202,8 @@ elseif(PLATFORM STREQUAL "rpiv2")
 	add_compile_options(-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard)
 	enable_language(ASM)
 	list(APPEND rtl_airband_extra_sources rtl_airband_neon.s)
+elseif(PLATFORM STREQUAL "rpiv4")
+	add_compile_options(-mcpu=cortex-a72 -mtune=cortex-a72 -mfpu=neon-fp-armv8 -mfloat-abi=hard)
 elseif(PLATFORM STREQUAL "armv7-generic")
 	add_compile_options(-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard)
 elseif(PLATFORM STREQUAL "armv8-generic")
@@ -223,7 +225,7 @@ elseif(PLATFORM STREQUAL "default")
 	# NOOP
 else()
 	message(FATAL_ERROR "Unknown platform '${PLATFORM}'. Valid options are:
-	rpiv1, rpiv2, armv7-generic, armv8-generic, native, default")
+	rpiv1, rpiv2, rpiv4, armv7-generic, armv8-generic, native, default")
 endif()
 
 # Try using VC GPU if enabled. Fallback to fftw3f if disabled or if VC lib not found


### PR DESCRIPTION
Hi,
I had problem with compilation for RPi4 (armv8-generic) so I have added option dedicated for RPi4.

Command:
`cmake -DPLATFORM=armv8-generic -DNFM=ON -DSOAPYSDR=ON -DPULSEAUDIO=ON ../`

Error message:
`cc1plus: error: ‘-mfloat-abi=hard’: selected architecture lacks an FPU
`
Additional information:
`[    0.000000] Linux version 6.1.0-rpi4-rpi-v8 (debian-kernel@lists.debian.org) (gcc-12 (Debian 12.2.0-14) 12.2.0, GNU ld (GNU Binutils for Debian) 2.40) #1 SMP PREEMPT Debian 1:6.1.54-1+rpt2 (2023-10-05)
[    0.000000] Machine model: Raspberry Pi 4 Model B Rev 1.2
`
Best regards,
Jacek
