### PR TITLE
CI build tweaks - `main` failing

### DIFF
--- a/.devcontainer/Dockerfile.ubuntu-20.04
+++ b/.devcontainer/Dockerfile.ubuntu-20.04
@@ -3,11 +3,17 @@ FROM ubuntu:20.04
 RUN sed -i 's/^# \(.*export LS_OPTIONS.*$\)/\1/g' ~/.bashrc && \
     sed -i 's/^# \(.*alias ll.*$\)/\1/g' ~/.bashrc
 
-RUN TZ=America/Los_Angeles DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
+RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
+RUN DEBIAN_FRONTEND=noninteractive \
+    apt-get update && \
+    apt-get install -y \
+        tzdata\
+        git \
+        sudo \
+        gdb
 
 WORKDIR /app
 COPY .github/install_dependencies /app/
-RUN apt-get install git sudo gdb -y
 RUN /app/install_dependencies
 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/.devcontainer/Dockerfile.ubuntu-latest
+++ b/.devcontainer/Dockerfile.ubuntu-latest
@@ -3,9 +3,17 @@ FROM ubuntu:latest
 RUN sed -i 's/^# \(.*export LS_OPTIONS.*$\)/\1/g' ~/.bashrc && \
     sed -i 's/^# \(.*alias ll.*$\)/\1/g' ~/.bashrc
 
+RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
+RUN DEBIAN_FRONTEND=noninteractive \
+    apt-get update && \
+    apt-get install -y \
+        tzdata\
+        git \
+        sudo \
+        gdb
+
 WORKDIR /app
 COPY .github/install_dependencies /app/
-RUN apt-get install git sudo gdb -y
 RUN /app/install_dependencies
 
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/.github/install_dependencies
+++ b/.github/install_dependencies
@@ -22,24 +22,7 @@ case "${unameOut}" in
 
     Darwin*)
         echo "Installing MacOS dependencies"
-        echo "running brew update"
         brew update
-
-        if [ -n "${GITHUB_ACTION}" ] ; then
-            echo "running in GitHub Workflow"
-            echo "running ${ImageOS} vsersion ${ImageVersion}"
-
-            # brew upgrade is taking 45+ min on macos-11 images, so skip it
-            if [[ "${ImageOS}" == "macos11" ]] ; then
-                echo "skipping brew upgrade"
-    
-            else
-                echo "running brew upgrade"
-                brew upgrade
-            fi
-        fi
-
-        echo "running brew install"
         brew install \
             lame \
             libshout \

--- a/.github/install_dependencies
+++ b/.github/install_dependencies
@@ -24,10 +24,13 @@ case "${unameOut}" in
         echo "Installing MacOS dependencies"
         brew update
 
+        printenv
+
         # brew upgrade is taking 45+ min on macos-11 images, so skip it
         if [[ $(sw_vers -productVersion | cut -d '.' -f 1) -le 11 ]] ; then 
             echo 'skipping brew upgrade'
         else
+            echo 'running brew upgrade'
             brew upgrade
         fi
 

--- a/.github/install_dependencies
+++ b/.github/install_dependencies
@@ -24,14 +24,18 @@ case "${unameOut}" in
         echo "Installing MacOS dependencies"
         brew update
 
-        printenv
+        if [ -v GITHUB_ACTION ] ; then
+            echo "running in GitHub Workflow"
+            echo "running ${ImageOS} vsersion ${ImageVersion}"
 
-        # brew upgrade is taking 45+ min on macos-11 images, so skip it
-        if [[ $(sw_vers -productVersion | cut -d '.' -f 1) -le 11 ]] ; then 
-            echo 'skipping brew upgrade'
-        else
-            echo 'running brew upgrade'
-            brew upgrade
+            # brew upgrade is taking 45+ min on macos-11 images, so skip it
+            if [[ "${ImageOS}" == "macos11" ]] ; then
+                echo 'skipping brew upgrade'
+    
+            else
+                echo 'running brew upgrade'
+                brew upgrade
+            fi
         fi
 
         brew install \

--- a/.github/install_dependencies
+++ b/.github/install_dependencies
@@ -22,22 +22,27 @@ case "${unameOut}" in
 
     Darwin*)
         echo "Installing MacOS dependencies"
+        echo "running brew update"
         brew update
 
-        if [ -v GITHUB_ACTION ] ; then
+        if [ -n "${GITHUB_ACTION}" ] ; then
             echo "running in GitHub Workflow"
             echo "running ${ImageOS} vsersion ${ImageVersion}"
 
             # brew upgrade is taking 45+ min on macos-11 images, so skip it
             if [[ "${ImageOS}" == "macos11" ]] ; then
-                echo 'skipping brew upgrade'
+                echo "skipping brew upgrade"
     
             else
-                echo 'running brew upgrade'
+                echo "running brew upgrade"
                 brew upgrade
             fi
         fi
 
+        exit -1
+
+
+        echo "running brew install"
         brew install \
             lame \
             libshout \

--- a/.github/install_dependencies
+++ b/.github/install_dependencies
@@ -39,9 +39,6 @@ case "${unameOut}" in
             fi
         fi
 
-        exit -1
-
-
         echo "running brew install"
         brew install \
             lame \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu-22.04, macos-12, rpi3b, macos-11, macos-13, ubuntu-20.04 ]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45 # runtime across all OSs, runs can get queued
+    timeout-minutes: 35 # runtime across all OSs, runs can get queued
     steps:
     - name: Checkout repository
       uses: actions/checkout@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-12, rpi3b, macos-11, macos-13, ubuntu-20.04 ]
+        os: [ ubuntu-22.04, macos-12, rpi3b, macos-13, ubuntu-20.04 ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 35 # runtime across all OSs, runs can get queued
     steps:
@@ -19,9 +19,7 @@ jobs:
       uses: actions/checkout@main
 
     - name: Install packaged dependencies
-      run: |
-        printenv
-        .github/install_dependencies
+      run: .github/install_dependencies
 
     - name: Configure
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu-22.04, macos-12, rpi3b, macos-11, macos-13, ubuntu-20.04 ]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 35 # runtime across all OSs, runs can get queued
+    timeout-minutes: 45 # runtime across all OSs, runs can get queued
     steps:
     - name: Checkout repository
       uses: actions/checkout@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,9 @@ jobs:
       uses: actions/checkout@main
 
     - name: Install packaged dependencies
-      run: .github/install_dependencies
+      run: |
+        printenv
+        .github/install_dependencies
 
     - name: Configure
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build*/
+.DS_Store
 .cache
 compile_commands.json
 rtl_airband*.log


### PR DESCRIPTION
- add more time to the CI workflow - mac build back over 35 minutes
- changes to Linux docker container to avoid apt issues with Docker caches