### PR TITLE
Fix Mac CI build failures on `main`

### DIFF
--- a/.github/install_dependencies
+++ b/.github/install_dependencies
@@ -22,7 +22,7 @@ case "${unameOut}" in
 
     Darwin*)
         echo "Installing MacOS dependencies"
-        brew update
+        #brew update
         brew install \
             lame \
             libshout \

--- a/.github/install_dependencies
+++ b/.github/install_dependencies
@@ -22,7 +22,15 @@ case "${unameOut}" in
 
     Darwin*)
         echo "Installing MacOS dependencies"
-        #brew update
+
+        # detect when running in github workflow and skip `brew update` (relay on fresh OS image)
+        if [ -n "${GITHUB_ACTION}" ] ; then
+            echo "running in GitHub Workflow, skipping brew update"
+            echo "running ${ImageOS} vsersion ${ImageVersion}"
+        else
+            brew update
+        fi
+
         brew install \
             lame \
             libshout \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 35 # runtime across all OSs, runs can get queued
     steps:
+    - name: Runner Info
+      run: printenv | sort
+
     - name: Checkout repository
       uses: actions/checkout@main
 


### PR DESCRIPTION
`brew install` will cause a `brew upgrade` on any installed package that is out of date, and one of these is failing.

Avoiding calling `brew update` when running as a GitHub Action and assuming the OS image is already up to date "enough" avoids the `brew upgrade` of those already installed packages