### PR TITLE
More mac build failures on `main`

### DIFF
--- a/.github/install_dependencies
+++ b/.github/install_dependencies
@@ -27,6 +27,8 @@ case "${unameOut}" in
         if [ -n "${GITHUB_ACTION}" ] ; then
             echo "running in GitHub Workflow, skipping brew update"
             export HOMEBREW_NO_AUTO_UPDATE=1
+            export HOMEBREW_NO_INSTALL_UPGRADE=1
+            export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
             echo "running ${ImageOS} vsersion ${ImageVersion}"
         else
             brew update

--- a/.github/install_dependencies
+++ b/.github/install_dependencies
@@ -26,6 +26,7 @@ case "${unameOut}" in
         # detect when running in github workflow and skip `brew update` (relay on fresh OS image)
         if [ -n "${GITHUB_ACTION}" ] ; then
             echo "running in GitHub Workflow, skipping brew update"
+            export HOMEBREW_NO_AUTO_UPDATE=1
             echo "running ${ImageOS} vsersion ${ImageVersion}"
         else
             brew update


### PR DESCRIPTION
Add environment variables to prevent `brew` from checking or updating already installed packages when running in GitHub Workflow