### PR TITLE
Detect `RTL_AIRBAND_VERION` when building from a release archive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required (VERSION 3.1)
 project (RTLSDR-Airband CXX)
 
+message(STATUS "running ${PROJECT_SOURCE_DIR}/scripts/find_version")
+
 execute_process(COMMAND ${PROJECT_SOURCE_DIR}/scripts/find_version
    OUTPUT_VARIABLE RTL_AIRBAND_VERSION
    OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.1)
 project (RTLSDR-Airband CXX)
 
-execute_process(COMMAND git describe --tags --abbrev --dirty --always
+execute_process(COMMAND ${PROJECT_SOURCE_DIR}/scripts/find_version
    OUTPUT_VARIABLE RTL_AIRBAND_VERSION
    OUTPUT_STRIP_TRAILING_WHITESPACE
    ERROR_VARIABLE RTL_AIRBAND_VERSION_ERROR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required (VERSION 3.1)
 project (RTLSDR-Airband CXX)
 
-message(STATUS "running ${PROJECT_SOURCE_DIR}/scripts/find_version")
-
 execute_process(COMMAND ${PROJECT_SOURCE_DIR}/scripts/find_version
    OUTPUT_VARIABLE RTL_AIRBAND_VERSION
    OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ WORKDIR /rtl_airband_build
 # WARNING: not copying in the whole repo, this may need to be updated if build files are added outside of src/
 COPY ./.git/ .git/
 COPY ./src/ src/
+COPY ./scripts/ scripts/
 COPY ./CMakeLists.txt .
 
 # configure and build

--- a/scripts/find_version
+++ b/scripts/find_version
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+PROJECT_ROOT_PATH="$(cd $(dirname "$0")/../ ; pwd)"
+PROJECT_GIT_DIR_PATH="${PROJECT_ROOT_PATH}/.git"
+PROJECT_DIR_NAME="$(basename ${PROJECT_ROOT_PATH})"
+
+# if there is a .git directory at the project root then rely on git for the version string
+if [ -d "${PROJECT_GIT_DIR_PATH}" ] ; then
+    git describe --tags --abbrev --dirty --always
+    exit 0
+fi
+
+# if the proejct root directory matches the naming convetion of an extracted archive then
+# get the version number out of that
+if [[ "${PROJECT_DIR_NAME}" =~ ^RTLSDR-Airband-[0-9]*\.[0-9]*\.[0-9]*$ ]]; then
+    echo ${PROJECT_DIR_NAME} | cut -d '-' -f 3
+    exit 0
+fi
+
+# print an error string to stderr (any output to stdout is considered success)
+>&2 echo "did not find a git root directory at ${PROJECT_GIT_DIR_PATH} and failed to extract a version from ${PROJECT_DIR_NAME}"


### PR DESCRIPTION
add script to get version string either from git or parent dir name