### PR TITLE
Fix mirisdr and add to docker builds

### DIFF
--- a/.github/install_dependencies
+++ b/.github/install_dependencies
@@ -18,6 +18,16 @@ case "${unameOut}" in
             librtlsdr-dev \
             libsoapysdr-dev \
             libpulse-dev
+
+        (
+            git clone https://github.com/f4exb/libmirisdr-4
+            cd libmirisdr-4
+            mkdir build
+            cd build
+            cmake ../
+            make install
+            ldconfig
+        )
         ;;
 
     Darwin*)

--- a/.github/install_dependencies
+++ b/.github/install_dependencies
@@ -25,8 +25,8 @@ case "${unameOut}" in
             mkdir build
             cd build
             cmake ../
-            make install
-            ldconfig
+            sudo make install
+            sudo ldconfig
         )
         ;;
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,14 @@ RUN git clone https://github.com/rtlsdrblog/rtl-sdr-blog && \
     dpkg -i librtlsdr-dev_*.deb && \
     dpkg -i rtl-sdr_*.deb
 
+# compile / install libmirisdr-4
+RUN git clone https://github.com/f4exb/libmirisdr-4 && \
+  cd libmirisdr-4 && \
+  mkdir build && \
+  cd build && \
+  cmake ../ && \
+  VERBOSE=1 make install && \
+  ldconfig
 
 # TODO: build anything from source?
 
@@ -89,6 +97,9 @@ RUN dpkg -i /tmp/librtlsdr0_*.deb && \
     echo 'blacklist dvb_usb_rtl28xxun' | tee --append /etc/modprobe.d/rtl_sdr.conf && \
     echo 'blacklist rtl2832' | tee --append /etc/modprobe.d/rtl_sdr.conf && \
     echo 'blacklist rtl2830' | tee --append /etc/modprobe.d/rtl_sdr.conf
+
+# install (from build container) libmirisdr-4
+COPY --from=build /usr/local/lib/libmirisdr.so.4 /usr/local/lib/
 
 # Copy rtl_airband from the build container
 COPY LICENSE /opt/rtl_airband/

--- a/src/input-mirisdr.cpp
+++ b/src/input-mirisdr.cpp
@@ -69,13 +69,12 @@ static bool mirisdr_nearest_gain(mirisdr_dev_t *dev, int target_gain, int *neare
 }
 
 static int mirisdr_find_device_by_serial(char const * const s) {
-	int device_count;
 	char vendor[256] = {0}, product[256] = {0}, serial[256] = {0};
-	device_count = mirisdr_get_device_count();
-	if(device_count < 1) {
+	int count = mirisdr_get_device_count();
+	if(count < 1) {
 		return -1;
 	}
-	for(int i = 0; i < device_count; i++) {
+	for(int i = 0; i < count; i++) {
 		mirisdr_get_device_usb_strings(i, vendor, product, serial);
 		if (strcmp(s, serial) != 0) {
 			continue;
@@ -102,8 +101,11 @@ int mirisdr_init(input_t * const input) {
 		error();
 	}
 
+	char transfer_str[] = "BULK";
+	char sample_format_str[] = "504_S8";
+
 	mirisdr_dev_t *miri = dev_data->dev;
-	int r = mirisdr_set_transfer(miri, (char *)"BULK");
+	int r = mirisdr_set_transfer(miri, transfer_str);
 	if (r < 0) {
 		log(LOG_ERR, "Failed to set bulk transfer mode for MiriSDR device #%d: error %d\n", dev_data->index, r);
 		error();
@@ -132,7 +134,7 @@ int mirisdr_init(input_t * const input) {
 		log(LOG_INFO, "Device #%d: gain set to %d dB\n", dev_data->index,
 			mirisdr_get_tuner_gain(miri));
 	}
-	r = mirisdr_set_sample_format(miri, (char *)"504_S8");
+	r = mirisdr_set_sample_format(miri, sample_format_str);
 	if (r < 0) {
 		log(LOG_ERR, "Failed to set sample format for device #%d: error %d\n", dev_data->index, r);
 		error();


### PR DESCRIPTION
- add installing libmirisdr-4 to both docker and CI builds
- fix warnings in input-mirisdr.cpp