### PR TITLE
Add feature: FIFO file output

### DIFF
--- a/config/basic_multichannel_with_fifo.conf
+++ b/config/basic_multichannel_with_fifo.conf
@@ -1,0 +1,61 @@
+# This is a minimalistic configuration file for RTLSDR-Airband.
+# Just a single RTL dongle with two AM channels in multichannel mode.
+# Each channel is sent to a single Icecast output.
+# Refer to https://github.com/charlie-foxtrot/RTLSDR-Airband/wiki
+# for description of keywords and config syntax.
+
+devices:
+({
+  type = "rtlsdr";
+  index = 0;
+  gain = 25;
+  centerfreq = 120.0;
+  correction = 80;
+  channels:
+  (
+    {
+      freq = 119.5;
+      outputs: (
+        {
+          type = "icecast";
+          server = "icecast.server.example.org";
+          port = 8080;
+          mountpoint = "TWR.mp3";
+          name = "Tower";
+          genre = "ATC";
+          username = "source";
+          password = "mypassword";
+        },
+        {
+          type = "fifofile";
+          directory = "/var/rtl_airband";
+          filename_template = "rtl_airband_119_5.fifo";
+        }
+
+      );
+    },
+    {
+      freq = 120.225;
+      outputs: (
+        {
+          type = "icecast";
+          server = "icecast.server.example.org";
+          port = 8080;
+          mountpoint = "GND.mp3";
+          name = "Ground";
+          genre = "ATC";
+          description = "My local airport - ground feed";
+          username = "source";
+          password = "mypassword";
+        },
+        {
+          type = "fifofile";
+          directory = "/var/rtl_airband";
+          filename_template = "rtl_airband_120_225.fifo";
+        }
+
+      );
+    }
+  );
+ }
+);

--- a/src/rtl_airband.h
+++ b/src/rtl_airband.h
@@ -105,6 +105,7 @@ enum output_type {
     O_ICECAST,
     O_FILE,
     O_RAWFILE,
+    O_FIFOFILE,
     O_MIXER,
     O_UDP_STREAM
 #ifdef WITH_PULSEAUDIO


### PR DESCRIPTION
This PR is to add the ability to create a FIFO file that is not rolled over every hour.
This adds the output option of `type = "fifofile"`.
Currently I have only tested that the FIFO is created, populated and not terminated every hour.
I have also added an example config to show how I am using the FIFO outputs.

I am not happy with the code replication that I have introduced, but as first PR I thought I'd submit working code, then in a later PR I can refactor the `elseif` concerning `rawfile` and `fifofile` to reduce this for readability and maintainability. I figured that this format of change in the code would be easier to follow rather than immediately introducing the refactoring also.

This is my first ever PR anywhere (I have submitted patches to projects previously though - just to give away my age :-/ ), so If I have got anything wrong, please be gentle, but advise so I can correct.
Also, if I have not followed best practices, or could do something to make your job as a maintainer easier, please also advise so I can rectify and learn.
